### PR TITLE
dockerize for hot-reloading

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,0 @@
-FROM tiangolo/uvicorn-gunicorn:python3.8
-LABEL authors="Nathan LeRoy, Michal Stolarczyk, Nathan Sheffield"
-
-COPY . /app
-RUN python -m pip install --upgrade pip
-RUN pip install --no-cache-dir --upgrade -r /app/requirements/requirements-all.txt

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 In the same directory as the `Dockerfile`:
 
 ```
-docker build -t pephub .
+docker build -t pephubserver .
 ```
 
 ### Running container for development:
@@ -22,7 +22,25 @@ pephub serve -p 5000
 Better, though, is to use the container. Mount the source code directory:
 
 ```
-docker run --rm -p 80:80 \   
+docker run -p 5000:80 \       
+-e MODULE_NAME="pephub.main" \
 -v $(pwd)/pephub:/app/pephub \
-pephub pephub serve  
+pephubserver /start-reload.sh
+```
+
+Your development server with hot-reloading will be served at http://localhost:5000
+
+### Running container for production:
+Build the container:
+
+```
+docker build -t pephubserver .
+```
+
+Run the container using the pephub `cli` as entrypoint:
+
+```
+docker run --rm -d -p 80:80 \
+--name pephubservercon \
+pephubserver pephub serve
 ```

--- a/pephub/main.py
+++ b/pephub/main.py
@@ -8,12 +8,17 @@ from ._version import __version__ as server_v
 from .const import LOG_FORMAT, PKG_NAME
 from .helpers import build_parser
 
+from .routers import version1
+
 app = FastAPI(
     title=PKG_NAME,
     description="a web interface and RESTful API for PEPs",
     version=server_v,
 )
 
+# build routes
+app.include_router(version1.router)
+app.include_router(version1.router, prefix="/v1")
 
 def main():
     global _LOGGER
@@ -31,13 +36,8 @@ def main():
     _LOGGER = logmuse.setup_logger(**logger_args)
 
     if args.command == "serve":
-        from .routers import version1
-
-        app.include_router(version1.router)
-        app.include_router(version1.router, prefix="/v1")
-        
         uvicorn.run(app, host="0.0.0.0", port=args.port, debug=args.debug)
-        
+
     else:
         _LOGGER.error(f"unknown command: {args.command}")
         sys.exit(1)


### PR DESCRIPTION
## Dockerize for hot-reloading.
Wanted to document my rationale/process in a PR for future reference. I emulated this server off of the [refgenieserver](https://github.com/refgenie/refgenieserver). I noticed there is a section in the `README` for running the container for development, which is also preferred according to the documentation there.

Running the container like this, however, doesn't give you hot-reloading which is crucial to the development of a server. I made two changes to allow for hot-reloading inside the Docker container.

### 1. Move `app.include_router()` calls **outside** `cli` entrypoint (`def main()`).
I noticed that calls are only made to `app.include_router()` if the `cli` is run with the `serve` command. I couldn't see a conflicting scope, so I lifted this up outside of `def main()` to facilitate change #2:

### 2. Change entrypoint to `/start-reload.sh`.
Originally the entrypoint is the `cli`. This doesn't work since hot reloading is [not supported](https://github.com/encode/uvicorn/issues/231) when running the sever programmatically (i.e. `uvicorn.run(...)`. Chaning the entrypoint when running docker to `/start-reload.sh`, we can run with debugging **iff** we specify the entrypoint module like so:

```
-e MODULE_NAME="pephub.main" 
```

Hence, why we lifted the router calls to the `main.py` global scope. As this allows the new entrypoint access to the app and the router objects. Finally, mounting your local server source code with `-v $(pwd)/pephub:/app/pephub \` gives us hot reloading.