### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ FROM python:3.10-slim
 LABEL authors="Nathan LeRoy, Nathan Sheffield"
 
 RUN apt-get update
+RUN apt-get install -y libpq-dev
 RUN apt-get install -y --no-install-recommends git
 
 EXPOSE 5432


### PR DESCRIPTION
The switch to `psycopg2` versus `psycopg-binary` seems to have broken deployment. Updating the docker file to install postgres dev dependencies should fix the issue.