### PR TITLE
Bug fixes and add warning to metadata standardizer for projects with 9+ columns

### DIFF
--- a/web/src/components/forms/components/pep-search-dropdown.tsx
+++ b/web/src/components/forms/components/pep-search-dropdown.tsx
@@ -65,6 +65,13 @@ export const PepSearchDropdown = (props: Props) => {
           value: `${n.namespace}/${n.name}:${n.tag}`,
         })) || []
       }
+      styles={{
+        control: (provided) => ({
+          ...provided,
+          borderRadius: '.375em',
+          borderColor: '#dee2e6'
+        })
+      }}
       placeholder="Search for PEPs"
       menuPlacement="bottom"
       controlShouldRenderValue={true}

--- a/web/src/components/modals/remove-pep-from-pop.tsx
+++ b/web/src/components/modals/remove-pep-from-pop.tsx
@@ -88,20 +88,19 @@ export const RemovePEPFromPOPModal: FC<Props> = ({
       <Modal.Footer>
         <button
           onClick={() => {
-            submit({
-              config: projectConfig?.config,
-              samples: currentPeps.filter((pep) => pep.sample_name !== `${namespaceToRemove}/${projectToRemove}:${tagToRemove}`),
-              subsamples: subSampleTable?.items,
-            });
-            // submit(
-            //   currentPeps.filter((pep) => pep.sample_name !== `${namespaceToRemove}/${projectToRemove}:${tagToRemove}`),
-            //   {
-            //     onSuccess: () => {
-            //       onSuccess();
-            //       onHide();
-            //     },
-            //   },
-            // );
+            submit(
+              {
+                config: projectConfig?.config,
+                samples: currentPeps.filter((pep) => pep.sample_name !== `${namespaceToRemove}/${projectToRemove}:${tagToRemove}`),
+                subsamples: subSampleTable?.items,
+              },
+              {
+                onSuccess: () => {
+                  onSuccess();
+                  onHide();
+                },
+              }
+            );
           }}
           disabled={confirmText !== `${namespaceToRemove}/${projectToRemove}:${tagToRemove}` || isSampleTablePending}
           type="button"

--- a/web/src/components/modals/standardize-metadata.tsx
+++ b/web/src/components/modals/standardize-metadata.tsx
@@ -50,6 +50,10 @@ export const StandardizeMetadataModal = (props: Props) => {
     setResetStandardizedData,
   } = props;
 
+  const maxColsExceeded = newSamples[0].length >= 9
+
+  console.log(maxColsExceeded)
+
   const { data: schemaOptions } = useStandardizerSchemas(namespace);
 
   const tabDataRaw = newSamples;
@@ -241,13 +245,23 @@ export const StandardizeMetadataModal = (props: Props) => {
                     <button
                       className="btn btn-success float-end w-100"
                       type="submit"
-                      disabled={selectedOption === null}
+                      disabled={selectedOption === null || maxColsExceeded}
                     >
                       Standardize!
                     </button>
                   </div>
                 </div>
               </form>
+
+              {maxColsExceeded && (
+                <div className='row'>
+                  <p className='text-sm mt-3 mb-1'>
+                    <strong>Note: </strong>
+                    Your project has nine or more columns. 
+                    Due to server constraints, we currently only support standardization of projects with fewer than nine columns on PEPhub.
+                  </p>
+                </div>
+              )}
             </div>
           </div>
 

--- a/web/src/components/modals/standardize-metadata.tsx
+++ b/web/src/components/modals/standardize-metadata.tsx
@@ -50,9 +50,7 @@ export const StandardizeMetadataModal = (props: Props) => {
     setResetStandardizedData,
   } = props;
 
-  const maxColsExceeded = newSamples[0].length >= 9
-
-  console.log(maxColsExceeded)
+  const maxColsExceeded = newSamples[0].length >= 9;
 
   const { data: schemaOptions } = useStandardizerSchemas(namespace);
 
@@ -304,7 +302,7 @@ export const StandardizeMetadataModal = (props: Props) => {
           <div>
             {whereDuplicates !== null && (
               <div className="text-danger me-auto mt-3 pt-2 d-inline-block">
-                Warning: ensure no duplicate column names have been selected.
+                <strong>Warning:</strong> ensure no duplicate column names have been selected.
               </div>
             )}
             <button

--- a/web/src/components/modals/standardize-metadata.tsx
+++ b/web/src/components/modals/standardize-metadata.tsx
@@ -243,7 +243,7 @@ export const StandardizeMetadataModal = (props: Props) => {
                     <button
                       className="btn btn-success float-end w-100"
                       type="submit"
-                      disabled={selectedOption === null || maxColsExceeded}
+                      disabled={selectedOption === null}
                     >
                       Standardize!
                     </button>
@@ -256,7 +256,7 @@ export const StandardizeMetadataModal = (props: Props) => {
                   <p className='text-sm mt-3 mb-1'>
                     <strong>Note: </strong>
                     Your project has nine or more columns. 
-                    Due to server constraints, we currently only support standardization of projects with fewer than nine columns on PEPhub.
+                    Due to server constraints, standardization of nine or more columns on PEPhub may take some time. Please be patient.
                   </p>
                 </div>
               )}

--- a/web/src/components/modals/standardize-metadata.tsx
+++ b/web/src/components/modals/standardize-metadata.tsx
@@ -50,8 +50,6 @@ export const StandardizeMetadataModal = (props: Props) => {
     setResetStandardizedData,
   } = props;
 
-  const PH_ID_COL = 'ph_id';
-
   const { data: schemaOptions } = useStandardizerSchemas(namespace);
 
   const tabDataRaw = newSamples;
@@ -267,7 +265,7 @@ export const StandardizeMetadataModal = (props: Props) => {
               </div>
 
               <form>
-                {Object.keys(standardizedData).filter(key => key !== 'ph_id').map((key, index) => (
+                {Object.keys(standardizedData).map((key, index) => (
                   <StandardizerTable
                     columnKey={key}
                     columnIndex={index}

--- a/web/src/components/namespace/project-cards/project-card-dropdown.tsx
+++ b/web/src/components/namespace/project-cards/project-card-dropdown.tsx
@@ -1,4 +1,4 @@
-import { FC, Fragment, useState } from 'react';
+import { FC, Fragment, useState, useEffect } from 'react';
 import { Button, ButtonGroup, Dropdown } from 'react-bootstrap';
 import toast from 'react-hot-toast';
 
@@ -28,6 +28,10 @@ export const ProjectCardDropdown: FC<Props> = (props) => {
   const { isPending: isRemovingStar, removeStar } = useRemoveStar(user?.login);
 
   const [localStarred, setLocalStarred] = useState(isStarred);
+
+  useEffect(() => {
+    setLocalStarred(isStarred);
+  }, [project]);
 
   return (
     <Dropdown as={ButtonGroup}>

--- a/web/src/components/namespace/project-cards/project-card-dropdown.tsx
+++ b/web/src/components/namespace/project-cards/project-card-dropdown.tsx
@@ -29,10 +29,6 @@ export const ProjectCardDropdown: FC<Props> = (props) => {
 
   const [localStarred, setLocalStarred] = useState(isStarred);
 
-  useEffect(() => {
-    setLocalStarred(isStarred);
-  }, [project]);
-
   return (
     <Dropdown as={ButtonGroup}>
       <Button

--- a/web/src/components/namespace/project-cards/project-card.tsx
+++ b/web/src/components/namespace/project-cards/project-card.tsx
@@ -1,4 +1,4 @@
-import { FC, Fragment, useState } from 'react';
+import { FC, Fragment, useState, useMemo} from 'react';
 
 import { ProjectAnnotation } from '../../../../types';
 import { useSession } from '../../../contexts/session-context';
@@ -23,8 +23,11 @@ export const ProjectCard: FC<Props> = ({ project }) => {
   const [showForkPEPModal, setShowForkPEPModal] = useState(false);
   const [copied, setCopied] = useState(false);
 
-  const isStarred = stars?.find(
-    (star) => star.namespace === project.namespace && star.name === project.name && star.tag === project.tag,
+  const isStarred = useMemo(() => 
+    !!stars?.find(
+      (star) => star.namespace === project.namespace && star.name === project.name && star.tag === project.tag
+    ),
+    [stars, project.namespace, project.name, project.tag]
   );
 
   return (
@@ -55,19 +58,17 @@ export const ProjectCard: FC<Props> = ({ project }) => {
             </span>
           ) : null}
         </div>
-        { !isLoading ? 
+        { !isLoading && (
           <ProjectCardDropdown
             project={project}
-            isStarred={!!isStarred}
+            isStarred={isStarred}
             copied={copied}
             setCopied={setCopied}
             setShowDeletePEPModal={setShowDeletePEPModal}
             setShowForkPEPModal={setShowForkPEPModal}
             starNumber={project?.stars_number}
           />
-          : null          
-        }
-        
+        )}
       </div>
       <div className="mb-0">
         {project.description ? (

--- a/web/src/components/namespace/project-cards/project-card.tsx
+++ b/web/src/components/namespace/project-cards/project-card.tsx
@@ -67,6 +67,7 @@ export const ProjectCard: FC<Props> = ({ project }) => {
             setShowDeletePEPModal={setShowDeletePEPModal}
             setShowForkPEPModal={setShowForkPEPModal}
             starNumber={project?.stars_number}
+            key={project?.digest}
           />
         )}
       </div>

--- a/web/src/components/pop/pop-card-dropdown.tsx
+++ b/web/src/components/pop/pop-card-dropdown.tsx
@@ -33,10 +33,6 @@ export const PopCardDropdown: FC<Props> = (props) => {
 
   const [localStarred, setLocalStarred] = useState(isStarred);
 
-  useEffect(() => {
-    setLocalStarred(isStarred);
-  }, [project]);
-
   return (
     <Dropdown as={ButtonGroup}>
       <Button

--- a/web/src/components/pop/pop-card-dropdown.tsx
+++ b/web/src/components/pop/pop-card-dropdown.tsx
@@ -1,4 +1,4 @@
-import { FC, Fragment } from 'react';
+import { FC, Fragment, useState, useEffect } from 'react';
 import { Button, ButtonGroup, Dropdown } from 'react-bootstrap';
 import toast from 'react-hot-toast';
 import { useParams, useSearchParams } from 'react-router-dom';
@@ -9,6 +9,7 @@ import { useAddStar } from '../../hooks/mutations/useAddStar';
 import { useRemoveStar } from '../../hooks/mutations/useRemoveStar';
 import { copyToClipboard } from '../../utils/etc';
 import { LoadingSpinner } from '../spinners/loading-spinner';
+import { numberWithCommas } from '../../utils/etc';
 
 interface Props {
   project: ProjectAnnotation;
@@ -17,23 +18,32 @@ interface Props {
   setCopied: (copied: boolean) => void;
   setShowForkPEPModal: (show: boolean) => void;
   setShowRemovePEPModal: (show: boolean) => void;
+  starNumber: number;
 }
 
 export const PopCardDropdown: FC<Props> = (props) => {
   let { namespace, project: name } = useParams();
 
-  const { project, isStarred, copied, setCopied, setShowForkPEPModal, setShowRemovePEPModal } = props;
+  const { project, isStarred, copied, setCopied, setShowForkPEPModal, setShowRemovePEPModal, starNumber } = props;
 
   const { user } = useSession();
 
   const { isPending: isAddingStar, addStar } = useAddStar(user?.login || '');
   const starRemoveMutation = useRemoveStar(user?.login || '');
 
+  const [localStarred, setLocalStarred] = useState(isStarred);
+
+  useEffect(() => {
+    setLocalStarred(isStarred);
+  }, [project]);
+
   return (
     <Dropdown as={ButtonGroup}>
       <Button
         disabled={isAddingStar || starRemoveMutation.isPending}
-        variant="outline-dark"
+        variant="outline"
+        className={isStarred ? 'border mt-1 shadow-none rounded-start-2 starred-button' : 'border mt-1 shadow-none rounded-start-2 star-button'} 
+        style={{zIndex: 2}}
         size="sm"
         onClick={() => {
           if (!user) {
@@ -54,42 +64,32 @@ export const PopCardDropdown: FC<Props> = (props) => {
         }}
       >
         {isStarred ? (
-          <Fragment>
-            <div className="d-flex align-items-center">
-              <i className="text-primary bi bi-star-fill me-1"></i>
-              <span className="text-primary">
-                s
-                {starRemoveMutation.isPending ? (
-                  <Fragment>
-                    {copied ? 'Copied!' : 'Star'}
-                    <LoadingSpinner className="w-4 h-4 spin ms-1 mb-tiny fill-secondary" />
-                  </Fragment>
-                ) : (
-                  <Fragment>{copied ? 'Copied!' : 'Star'}</Fragment>
-                )}
-              </span>
-            </div>
-          </Fragment>
+          <div className="d-flex align-items-center text-sm">
+            <i className="bi bi-star-fill me-1 position-relative" style={{paddingRight: '2px', marginTop: '-0.666666px'}}></i>
+            <span className='fw-semibold'>
+              <Fragment>
+                {copied ? 'Copied!' : (localStarred ? numberWithCommas(starNumber) : numberWithCommas(starNumber + 1))}
+              </Fragment>
+            </span>
+          </div>
         ) : (
-          <Fragment>
-            <div className="d-flex align-items-center">
-              <i className="bi bi-star me-1"></i>
-              <span>
-                {starRemoveMutation.isPending ? (
-                  <Fragment>
-                    {copied ? 'Copied!' : 'Star'}
-                    <LoadingSpinner className="w-4 h-4 spin ms-1 mb-tiny fill-secondary" />
-                  </Fragment>
-                ) : (
-                  <Fragment>{copied ? 'Copied!' : 'Star'}</Fragment>
-                )}
-              </span>
-            </div>
-          </Fragment>
+          <div className="d-flex align-items-center text-sm">
+            <i className="bi bi-star me-1 position-relative" style={{paddingRight: '2px', marginTop: '-0.666666px'}}></i>
+            <span className='fw-normal'>
+              <Fragment>
+                {copied ? 'Copied!' : (localStarred ? numberWithCommas(starNumber - 1) : numberWithCommas(starNumber))}
+              </Fragment>
+            </span>
+          </div>
         )}
       </Button>
-      <Dropdown.Toggle split variant="outline-dark" id="dropdown-split-basic" />
-      <Dropdown.Menu>
+      <Dropdown.Toggle 
+        split 
+        variant="outline"
+        className='border mt-1 me-1 shadow-none rounded-end-2 star-dropdown-button'
+        style={{zIndex: 2}}
+        id="dropdown-split-basic" />
+      <Dropdown.Menu className='border border-light-subtle shadow-sm'>
         <Dropdown.Item href={`/${project.namespace}/${project.name}`}>
           <i className="bi bi-eye me-1"></i>
           View

--- a/web/src/components/pop/pop-card.tsx
+++ b/web/src/components/pop/pop-card.tsx
@@ -68,6 +68,7 @@ export const PopCard: FC<Props> = ({ project, currentPeps, parentName, parentNam
           setShowForkPEPModal={setShowForkPEPModal}
           setShowRemovePEPModal={setShowRemovePEPModal}
           starNumber={project?.stars_number}
+          key={project?.digest}
         />
       </div>
       <div className="mb-0">

--- a/web/src/components/pop/pop-card.tsx
+++ b/web/src/components/pop/pop-card.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC, useState, useMemo } from 'react';
 
 import { ProjectAnnotation, Sample } from '../../../types';
 import { useSession } from '../../contexts/session-context';
@@ -25,19 +25,21 @@ export const PopCard: FC<Props> = ({ project, currentPeps, parentName, parentNam
   const [showRemovePEPModal, setShowRemovePEPModal] = useState(false);
   const [copied, setCopied] = useState(false);
 
-  const isStarred = stars?.find(
-    (star) => star.namespace === project.namespace && star.name === project.name && star.tag === project.tag,
+  const isStarred = useMemo(() => 
+    !!stars?.find(
+      (star) => star.namespace === project.namespace && star.name === project.name && star.tag === project.tag
+    ),
+    [stars, project.namespace, project.name, project.tag]
   );
 
   return (
     <div
       id={`project-card-${project.namespace}/${project.name}:${project.tag}`}
-      className="w-100 border border-dark rounded shadow-sm p-2 mt-3"
-      style={{ backgroundColor: '#f6f8fa' }}
+      className="w-100 border rounded shadow-sm ps-3 pe-2 pb-3 pt-2 mt-3 bg-body-tertiary card namespace-card"
     >
       <div className="d-flex flex-row align-items-start justify-content-between">
         <div className="d-flex flex-row align-items-center">
-          <a className="fw-bold fs-4" href={`${project.namespace}/${project.name}?tag=${project.tag}`}>
+          <a className="fw-semibold fs-4 stretched-link text-decoration-none text-primary-emphasis" href={`${project.namespace}/${project.name}?tag=${project.tag}`}>
             {project.namespace}/{project.name}:{project.tag}
           </a>
           {project.is_private ? (
@@ -60,52 +62,51 @@ export const PopCard: FC<Props> = ({ project, currentPeps, parentName, parentNam
         </div>
         <PopCardDropdown
           project={project}
-          isStarred={!!isStarred}
+          isStarred={isStarred}
           copied={copied}
           setCopied={setCopied}
           setShowForkPEPModal={setShowForkPEPModal}
           setShowRemovePEPModal={setShowRemovePEPModal}
+          starNumber={project?.stars_number}
         />
       </div>
-      <div>
-        <div className="d-flex flex-row align-items-center">
-          <div className="me-4">
-            <i className="bi bi-star-fill"></i>
-            <span className="mx-1">{project.stars_number || 0}</span>
-          </div>
-          <div className="me-4">
-            <label className="fw-bold">No. of samples:</label>
-            <span className="mx-1">{project.number_of_samples}</span>
-          </div>
-          <div>
-            <label className="fw-bold">Schema:</label>
-            <span className="mx-1">{project.pep_schema || 'No schema'}</span>
-          </div>
-        </div>
-        <div className="mb-0">
-          {project.description ? (
-            <MarkdownToText>{project.description}</MarkdownToText>
-          ) : (
-            <em>
-              <span className="text-muted text-italic">No description</span>
-            </em>
-          )}
-        </div>
+      <div className="mb-0">
+        {project.description ? (
+          <MarkdownToText>{project.description}</MarkdownToText>
+        ) : (
+          <em>
+            <span className="text-muted text-italic">No description</span>
+          </em>
+        )}
       </div>
-      <div className="mt-3">
-        <div className="d-flex flex-row align-items-center text-muted">
-          <small>
-            <span className="me-3">
-              <i className="bi bi-calendar3"></i>
-              <span className="mx-1">Created:</span>
-              <span id="project-submission-date">{dateStringToDateTime(project.submission_date)}</span>
-              <i className="ms-4 bi bi-calendar3"></i>
-              <span className="mx-1">Updated:</span>
-              <span id="project-update-date">{dateStringToDateTime(project.last_update_date)}</span>
-            </span>
-            <span className="me-5">{project.digest}</span>
-          </small>
-        </div>
+      <div className="d-flex flex-row align-items-center mt-3 text-sm">
+        <span className="me-3">
+          <span className="fw-semibold">Sample Count:</span>
+          <span className="mx-1">{project.number_of_samples}</span>
+        </span>
+        <span>
+          <span className="fw-semibold">Schema:</span>
+          <span className="mx-1">{project.pep_schema || 'No schema'}</span>
+        </span>
+      </div>
+      <div className="d-flex flex-row align-items-center text-mute text-sm">
+        <span className="me-3">
+          <span className="fw-semibold">Created:</span>
+          <span className="mx-1" id="project-submission-date">{dateStringToDateTime(project.submission_date)}</span>
+        </span>
+        <span>
+          <span className="fw-semibold">Updated:</span>
+          <span className="mx-1" id="project-update-date">{dateStringToDateTime(project.last_update_date)}</span>
+        </span>
+        {project?.forked_from && (
+          <div className="p-1 border rounded fw-bold me-1 bg-white ms-auto position-relative forked-link" style={{zIndex: 2, margin: '-1.25em 0 -1em'}}>
+            <i className="bi bi-bezier2"></i>
+            <span className="ms-1">Forked from</span>
+            <a className="text-decoration-none ms-1 stretched-link" href={`/${project?.forked_from.replace(':', '?tag=')}`}>
+              {project?.forked_from}
+            </a>
+          </div>
+        )}
       </div>
       <ForkPEPModal
         show={showForkPEPModal}

--- a/web/src/components/pop/pop-interface.tsx
+++ b/web/src/components/pop/pop-interface.tsx
@@ -57,7 +57,7 @@ export const PopInterface = (props: Props) => {
     return (
       <Fragment>
         <div className="px-2">
-          <div className="mt-3 border-top w-100"></div>
+          <div className="mt-1 w-100"></div>
           <div className="px-2">
             <div className="d-flex flex-column">
               {allProjectsInfo?.results.map((project: ProjectAnnotation | null) =>

--- a/web/src/components/pop/pop-interface.tsx
+++ b/web/src/components/pop/pop-interface.tsx
@@ -8,19 +8,24 @@ import { useSampleTableMutation } from '../../hooks/mutations/useSampleTableMuta
 import { useMultiProjectAnnotation } from '../../hooks/queries/useMultiProjectAnnotation';
 import { useProjectAnnotation } from '../../hooks/queries/useProjectAnnotation';
 import { useSampleTable } from '../../hooks/queries/useSampleTable';
+import { useSubsampleTable } from '../../hooks/queries/useSubsampleTable';
+import { useProjectConfig } from '../../hooks/queries/useProjectConfig';
 import { NamespaceSearchDropdown } from '../forms/components/namespace-search-dropdown';
 import { PepSearchDropdown } from '../forms/components/pep-search-dropdown';
 import { ProjectCardPlaceholder } from '../placeholders/project-card-placeholder';
 import { LoadingSpinner } from '../spinners/loading-spinner';
 import { PopCard } from './pop-card';
+import { useTotalProjectChangeMutation } from '../../hooks/mutations/useTotalProjectChangeMutation';
 
 type Props = {
   projectInfo: ReturnType<typeof useProjectAnnotation>['data'];
   sampleTable: ReturnType<typeof useSampleTable>['data'];
+  subSampleTable: ReturnType<typeof useSubsampleTable>['data'];
+  projectConfig: ReturnType<typeof useProjectConfig>['data'];
 };
 
 export const PopInterface = (props: Props) => {
-  const { projectInfo } = props;
+  const { projectInfo, subSampleTable, projectConfig } = props;
 
   const { namespace, projectName, tag } = useProjectPage();
 
@@ -38,7 +43,8 @@ export const PopInterface = (props: Props) => {
   const [addToPopRegistry, setAddToPopRegistry] = useState<string | undefined>(undefined);
   const [isAddingNew, setIsAddingNew] = useState<boolean>(false);
 
-  const { isPending: isSampleTablePending, submit } = useSampleTableMutation(namespace, projectName, tag);
+  // const { isPending: isSampleTablePending, submit } = useSampleTableMutation(namespace, projectName, tag);
+  const { isPending: isSampleTablePending, submit } = useTotalProjectChangeMutation(namespace, projectName, tag);
 
   if (isLoading) {
     return (
@@ -119,15 +125,19 @@ export const PopInterface = (props: Props) => {
                             return;
                           }
                           let newPeps = peps?.items || [];
-                          const [newNamespace, newPojectNameAndTag] = addToPopRegistry.split('/');
-                          const [newProjectName, newProjectTag] = newPojectNameAndTag.split(':');
+                          const [newNamespace, newProjectNameAndTag] = addToPopRegistry.split('/');
+                          const [newProjectName, newProjectTag] = newProjectNameAndTag.split(':');
                           newPeps?.push({
                             sample_name: `${newNamespace}/${newProjectName}:${newProjectTag}`,
                             namespace: newNamespace,
                             name: newProjectName,
                             tag: newProjectTag,
                           });
-                          submit(newPeps);
+                          submit({
+                            config: projectConfig?.config,
+                            samples: newPeps,
+                            subsamples: subSampleTable?.items,
+                          });
                         }}
                         disabled={addToPopNamespace === '' || addToPopRegistry === '' || isSampleTablePending}
                       >

--- a/web/src/components/project/project-info-footer.tsx
+++ b/web/src/components/project/project-info-footer.tsx
@@ -46,7 +46,7 @@ export const ProjectInfoFooter = () => {
           </div>
           <div className="col-sm-auto">
             <i className="bi bi-arrows-expand"></i>
-            <span className="mx-1">Sample Count:</span>
+            <span className="mx-1">{projectInfo?.pop ? 'Project' : 'Sample'} Count:</span>
             <span id="project-update-date">
               {currentHistoryId !== null
                 ? projectHistoryQuery.data?._sample_dict.length

--- a/web/src/components/project/project-interface.tsx
+++ b/web/src/components/project/project-interface.tsx
@@ -74,7 +74,7 @@ export const ProjectInterface = (props: Props) => {
     view,
     enabled: !!view,
   });
-  const viewSamples = viewData?._samples || [];
+  const viewSamples = viewData?.samples || [];
 
   // form to store project updated fields temporarily
   // on the client before submitting to the server

--- a/web/src/components/project/project-interface.tsx
+++ b/web/src/components/project/project-interface.tsx
@@ -23,7 +23,6 @@ import { SampleTable } from '../tables/sample-table';
 import { ProjectConfigEditor } from './project-config';
 import { ProjectValidationAndEditButtons } from './project-validation-and-edit-buttons';
 import { StandardizeMetadataModal } from '../modals/standardize-metadata';
-
 import { useStandardizeModalStore } from '../../hooks/stores/useStandardizeModalStore'
 
 type Props = {
@@ -106,7 +105,7 @@ export const ProjectInterface = (props: Props) => {
     try {
       const samplesParsed = arraysToSampleList(values.samples, 'Sample');
       const subsamplesParsed = arraysToSampleList(values.subsamples, 'Subsample');
-      const configParsed = yaml.load(values.config) as Record<string, unknown>;
+      // const configParsed = yaml.load(values.config) as Record<string, unknown>;
       
       // // check if 'name' value exists in config for PEPhub PEP
       // if (!('name' in configParsed) || (('name' in configParsed) && (!configParsed.name))) {

--- a/web/src/components/project/project-page-header-bar.tsx
+++ b/web/src/components/project/project-page-header-bar.tsx
@@ -173,7 +173,7 @@ export const ProjectHeaderBar = (props: Props) => {
                     <i className="me-1 bi bi-bezier2"></i>
                     Fork
                   </Dropdown.Item>
-                  {!projectInfo.pop && (
+                  {!projectInfo?.pop && (
                     <>
                       <Dropdown.Item onClick={() => setShowAddToPOPModal(true)}>
                         <i className="me-1 bi bi-plus-circle"></i>

--- a/web/src/components/project/project-page-header-bar.tsx
+++ b/web/src/components/project/project-page-header-bar.tsx
@@ -173,10 +173,14 @@ export const ProjectHeaderBar = (props: Props) => {
                     <i className="me-1 bi bi-bezier2"></i>
                     Fork
                   </Dropdown.Item>
-                  <Dropdown.Item onClick={() => setShowAddToPOPModal(true)}>
-                    <i className="me-1 bi bi-plus-circle"></i>
-                    Add to POP
-                  </Dropdown.Item>
+                  {!projectInfo.pop && (
+                    <>
+                      <Dropdown.Item onClick={() => setShowAddToPOPModal(true)}>
+                        <i className="me-1 bi bi-plus-circle"></i>
+                        Add to POP
+                      </Dropdown.Item>
+                    </>
+                  )}
                 </Fragment>
               )}
             </Fragment>
@@ -199,14 +203,18 @@ export const ProjectHeaderBar = (props: Props) => {
                     <i className="me-1 bi bi-pencil-square"></i>
                     Edit
                   </Dropdown.Item>
-                  <Dropdown.Item onClick={() => setShowProjectHistoryModal(true)}>
-                    <i className="me-1 bi bi-stopwatch" />
-                    History
-                  </Dropdown.Item>
-                  <Dropdown.Item onClick={() => setShowStandardizeMetadataModal(true)}>
-                    <i className="me-1 bi bi-magic"></i>
-                    Standardize
-                  </Dropdown.Item>
+                  {!projectInfo.pop && (
+                    <>
+                      <Dropdown.Item onClick={() => setShowProjectHistoryModal(true)}>
+                      <i className="me-1 bi bi-stopwatch" />
+                        History
+                      </Dropdown.Item>
+                      <Dropdown.Item onClick={() => setShowStandardizeMetadataModal(true)}>
+                        <i className="me-1 bi bi-magic"></i>
+                        Standardize
+                      </Dropdown.Item>
+                    </>
+                  )}
                   <Dropdown.Item className="text-danger" onClick={() => setShowDeletePEPModal(true)}>
                     <i className="me-1 bi bi-trash3"></i>
                     Delete

--- a/web/src/components/project/project-page-header-bar.tsx
+++ b/web/src/components/project/project-page-header-bar.tsx
@@ -19,10 +19,8 @@ import { downloadZip } from '../../utils/project';
 import { ProjectHistoryModal } from '../modals/project-history';
 import { ProjectHeaderBarPlaceholder } from './placeholders/project-header-bar-placeholder';
 import { ProjectStars } from './project-stars'
-
 import { useStandardizeModalStore } from '../../hooks/stores/useStandardizeModalStore'
 import { useSampleTable } from '../../hooks/queries/useSampleTable'
-
 
 type Props = {
   sampleTable: ReturnType<typeof useSampleTable>['data'];

--- a/web/src/components/project/project-stars.tsx
+++ b/web/src/components/project/project-stars.tsx
@@ -1,4 +1,4 @@
-import { FC, Fragment, useState } from 'react';
+import { FC, Fragment, useState, useEffect } from 'react';
 import { Button, ButtonGroup, Dropdown } from 'react-bootstrap';
 import toast from 'react-hot-toast';
 
@@ -22,6 +22,10 @@ export const ProjectStars: FC<Props> = (props) => {
   const { isPending: isRemovingStar, removeStar } = useRemoveStar(user?.login);
 
   const [localStarred, setLocalStarred] = useState(isStarred);
+
+  useEffect(() => {
+    setLocalStarred(isStarred);
+  }, [project]);
 
   return (
     <Button

--- a/web/src/components/project/view-selector.tsx
+++ b/web/src/components/project/view-selector.tsx
@@ -98,11 +98,6 @@ export const ViewSelector = (props: ViewSelectorProps) => {
                   searchParams.set('view', selectedOption.value);
                   setSearchParams(searchParams);
                 }
-                setTimeout(() => {
-                  if (selectRef.current) {
-                    selectRef.current.blur();
-                  }
-                }, 50);
               }}
               isDisabled={projectViews?.views.length === 0 || projectViewsIsLoading}
               isClearable={false}

--- a/web/src/components/tables/browse-table.tsx
+++ b/web/src/components/tables/browse-table.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { HotTable } from '@handsontable/react';
 import Handsontable from 'handsontable';
+
 import { formatToPercentage } from '../../utils/etc';
 import { useSampleTable } from '../../hooks/queries/useSampleTable';
 import { arraysToSampleList, sampleListToArrays } from '../../utils/sample-table';
@@ -14,13 +15,22 @@ type BrowseTableProps = {
 
 export const BrowseTable = (props: BrowseTableProps) => {
   const { namespace, project, tag } = props;
+
+  const PH_ID_COL = 'ph_id';
+
   const { data: tabData, isFetching } = useSampleTable({
     namespace,
     project,
     tag,
     enabled: true
   });
+
   const tabSamples = tabData?.items || [];
+
+  const tabSamplesNoPHID = sampleListToArrays(tabSamples.map(sample => {
+    const { [PH_ID_COL]: _, ...rest } = sample;
+    return rest;
+  }));
 
   return (
     <>
@@ -33,7 +43,7 @@ export const BrowseTable = (props: BrowseTableProps) => {
           <p className='fw-medium text-sm mb-1'>Sample Table:</p>
           <div className="col overflow-auto border border-secondary-subtle rounded-2 shadow-sm p-0">
             <HotTable
-              data={sampleListToArrays(tabSamples)}
+              data={tabSamplesNoPHID}
               colHeaders={false}
               rowHeaders={true}
               width="100%"

--- a/web/src/components/tables/standardizer-table.tsx
+++ b/web/src/components/tables/standardizer-table.tsx
@@ -56,7 +56,7 @@ export const StandardizerTable = (props: StandardizerTableProps) => {
             ) : null}
             <div className="col-6 text-center">
               <div
-                className="overflow-auto border border-secondary-subtle rounded-2 shadow-sm p-0"
+                className="w-100 h-100 overflow-auto border border-secondary-subtle rounded-2 shadow-sm p-0"
                 style={{ bottom: '-1px' }}
               >
                 <HotTable

--- a/web/src/components/tables/standardizer-table.tsx
+++ b/web/src/components/tables/standardizer-table.tsx
@@ -29,8 +29,11 @@ export const StandardizerTable = (props: StandardizerTableProps) => {
     tableData,
   } = props;
 
+  const PH_ID_COL = 'ph_id';
+
   return (
     <>
+      { columnKey !== PH_ID_COL && 
         <div className="mb-3" key={columnKey}>
           <div
             className={
@@ -53,7 +56,7 @@ export const StandardizerTable = (props: StandardizerTableProps) => {
             ) : null}
             <div className="col-6 text-center">
               <div
-                className="w-100 h-100 border border-secondary-subtle rounded-2 shadow-sm"
+                className="overflow-auto border border-secondary-subtle rounded-2 shadow-sm p-0"
                 style={{ bottom: '-1px' }}
               >
                 <HotTable
@@ -147,6 +150,7 @@ export const StandardizerTable = (props: StandardizerTableProps) => {
             <br />
           </div>
         </div>
+      }
     </>
   );
 };

--- a/web/src/components/tables/standardizer-table.tsx
+++ b/web/src/components/tables/standardizer-table.tsx
@@ -94,7 +94,7 @@ export const StandardizerTable = (props: StandardizerTableProps) => {
                         if (row === 0) {
                           td.style.fontWeight = 'bold';
                           if (whereDuplicates?.includes(columnIndex)) {
-                            td.style.color = 'red';
+                            td.style.color = '#dc3545';
                           }
                         }
                       },

--- a/web/src/pages/Project.tsx
+++ b/web/src/pages/Project.tsx
@@ -118,7 +118,7 @@ export const ProjectPage = () => {
         <div className='d-flex flex-column' style={{height: 'calc(100vh - 85px)'}}>
           <ProjectHeader sampleTable={sampleTableQuery.data} sampleTableIndex={sampleTableIndex || 'sample_name'}/>
           {projectInfo?.pop && !forceTraditionalInterface ? (
-            <PopInterface projectInfo={projectInfo} sampleTable={sampleTableQuery.data} />
+            <PopInterface projectInfo={projectInfo} sampleTable={sampleTableQuery.data} subSampleTable={subSampleTableQuery.data} projectConfig={projectConfigQuery.data} />
           ) : (
             <ProjectInterface
               key={`${projectAnnotationQuery.dataUpdatedAt}-${projectConfigQuery.dataUpdatedAt}-${sampleTableQuery.dataUpdatedAt}-${subSampleTableQuery.dataUpdatedAt}`}

--- a/web/types.ts
+++ b/web/types.ts
@@ -116,7 +116,7 @@ export interface ProjectViewAnnotation {
   name: string;
   description?: string;
   number_of_samples: number;
-  _samples: Sample[];
+  samples: Sample[];
 }
 
 export type ProjectAllHistory = {


### PR DESCRIPTION
Is this too big to be a hotfix patch?

Things addressed (all small frontend things): 
- disable metadata standardizer for projects with 9+ cols
- hide ph_id column in browse page
- adjust how ph_id column is hidden in metadata standardizer modal
- update POP interface styling (regardless, adding or removing PEPs from  POPs seems broken in backend, not sure why)
- hotfix views not working (fixed typo in types.ts)
- fixed star count messing up when adding/removing PEPs from namespace page or updating a project in project page (couldn't figure out how to do it without useEffect)